### PR TITLE
Add Webhooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 build
 bin
+.idea
+*.iml
+*test_config.json

--- a/src/main/java/co/upvest/TenancyAPI.java
+++ b/src/main/java/co/upvest/TenancyAPI.java
@@ -19,6 +19,7 @@ public class TenancyAPI extends APIClient {
     private UsersEndpoint usersEndpoint;
     private AssetsEndpoint assetsEndpoint;
     private WalletsEndpoint walletsEndpoint;
+    private WebhooksEndpoint webhooksEndpoint;
 
     public @NotNull TenancyAPI(@NotNull String key, @NotNull String secret, @NotNull String passphrase) {
         this(getDefaultHost(), key, secret, passphrase);
@@ -54,6 +55,12 @@ public class TenancyAPI extends APIClient {
         if (walletsEndpoint == null)
             walletsEndpoint = new WalletsEndpoint(this);
         return walletsEndpoint;
+    }
+
+    public @NotNull WebhooksEndpoint webhooks() {
+        if (webhooksEndpoint == null)
+            webhooksEndpoint = new WebhooksEndpoint(this);
+        return webhooksEndpoint;
     }
 
     public @NotNull Echo echo(@NotNull String what) throws IOException {

--- a/src/main/java/co/upvest/endpoints/WebhooksEndpoint.java
+++ b/src/main/java/co/upvest/endpoints/WebhooksEndpoint.java
@@ -1,0 +1,155 @@
+package co.upvest.endpoints;
+
+import co.upvest.*;
+import co.upvest.models.*;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.squareup.moshi.*;
+
+import org.jetbrains.annotations.NotNull;
+
+import okhttp3.*;
+import org.jetbrains.annotations.Nullable;
+
+public class WebhooksEndpoint implements Webhook.Endpoint<Webhook> {
+
+    private TenancyAPI apiClient;
+
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+
+    final Moshi moshi = new Moshi.Builder().build();
+    final JsonAdapter<Webhook> webhookAdapter = moshi.adapter(Webhook.class);
+    final JsonAdapter<Cursor<Webhook>> webhooksCursorAdapter = moshi.adapter(Types.newParameterizedType(Cursor.class, Webhook.class));
+
+    public WebhooksEndpoint(@NotNull TenancyAPI tenancy) {
+        this.apiClient = tenancy;
+    }
+
+    public @NotNull
+    Cursor<@NotNull Webhook> list() throws IOException {
+        return list(null);
+    }
+
+    /**
+     * @param pageSize number of Webhooks to load per page (maximum 100)
+     */
+    public @NotNull
+    Cursor<@NotNull Webhook> list(int pageSize) throws IOException {
+        HttpUrl url = apiClient.getBaseUrl()
+                .addPathSegment("tenancy")
+                .addPathSegment("webhooks")
+                .addPathSegment("")
+                .addQueryParameter("page_size", String.valueOf(pageSize))
+                .build();
+
+        Request request = new Request.Builder()
+                .url(url)
+                .build();
+
+        Response response = apiClient.getClient().newCall(request).execute();
+        Cursor<Webhook> webhooks = webhooksCursorAdapter.fromJson(response.body().source());
+        webhooks.setEndpoint(this);
+        return webhooks;
+    }
+
+    /**
+     * Load a page
+     *
+     * @param cursor url of the (next/previous) page to load
+     */
+    public @NotNull
+    Cursor<@NotNull Webhook> list(@Nullable String cursor) throws IOException {
+        HttpUrl url;
+
+        if (cursor == null) {
+            url = apiClient.getBaseUrl()
+                    .addPathSegment("tenancy")
+                    .addPathSegment("webhooks")
+                    .addPathSegment("")
+                    .build();
+        } else {
+            url = HttpUrl.parse(cursor);
+        }
+
+        Request request = new Request.Builder()
+                .url(url)
+                .build();
+
+        Response response = apiClient.getClient().newCall(request).execute();
+        Cursor<Webhook> webhooks = webhooksCursorAdapter.fromJson(response.body().source());
+        webhooks.setEndpoint(this);
+        return webhooks;
+    }
+
+    public @NotNull Webhook create(@NotNull WebhookParams params) throws IOException {
+        HttpUrl url = apiClient.getBaseUrl()
+                .addPathSegment("tenancy")
+                .addPathSegment("webhooks")
+                .addPathSegment("")
+                .build();
+
+        Request request = new Request.Builder()
+                .url(url)
+                .post(RequestBody.create(JSON, apiClient.objectAdapter.toJson(params.toMap())))
+                .build();
+
+        Response response = apiClient.getClient().newCall(request).execute();
+        Webhook webhook = webhookAdapter.fromJson(response.body().source());
+
+        return webhook;
+    }
+
+    public boolean verify(String verifyUrl) throws IOException {
+        HttpUrl url = apiClient.getBaseUrl()
+                .addPathSegment("tenancy")
+                .addPathSegment("webhooks")
+                .addPathSegment("")
+                .build();
+
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("verify_url", verifyUrl);
+        Request request = new Request.Builder()
+                .url(url)
+                .post(RequestBody.create(JSON, apiClient.objectAdapter.toJson(params)))
+                .build();
+
+        Response response = apiClient.getClient().newCall(request).execute();
+        return response.code() == 204;
+    }
+
+    public @NotNull Webhook get(@NotNull String id) throws IOException {
+        HttpUrl url = apiClient.getBaseUrl()
+                .addPathSegment("tenancy")
+                .addPathSegment("webhooks")
+                .addPathSegment(id)
+                .build();
+
+        Request request = new Request.Builder()
+                .url(url)
+                .build();
+
+        Response response = apiClient.getClient().newCall(request).execute();
+        Webhook webhook = webhookAdapter.fromJson(response.body().source());
+        return webhook;
+    }
+
+    public @NotNull boolean delete(@NotNull String id) throws IOException {
+        HttpUrl url = apiClient.getBaseUrl()
+                .addPathSegment("tenancy")
+                .addPathSegment("webhooks")
+                .addPathSegment(id)
+                .build();
+
+        Request request = new Request.Builder()
+                .url(url)
+                .delete()
+                .build();
+
+        Response response = apiClient.getClient().newCall(request).execute();
+        return response.code() == 204;
+    }
+
+}

--- a/src/main/java/co/upvest/endpoints/WebhooksEndpoint.java
+++ b/src/main/java/co/upvest/endpoints/WebhooksEndpoint.java
@@ -105,7 +105,7 @@ public class WebhooksEndpoint implements Webhook.Endpoint<Webhook> {
     public boolean verify(String verifyUrl) throws IOException {
         HttpUrl url = apiClient.getBaseUrl()
                 .addPathSegment("tenancy")
-                .addPathSegment("webhooks")
+                .addPathSegment("webhooks-verify")
                 .addPathSegment("")
                 .build();
 
@@ -117,7 +117,7 @@ public class WebhooksEndpoint implements Webhook.Endpoint<Webhook> {
                 .build();
 
         Response response = apiClient.getClient().newCall(request).execute();
-        return response.code() == 204;
+        return response.code() == 201;
     }
 
     public @NotNull Webhook get(@NotNull String id) throws IOException {

--- a/src/main/java/co/upvest/models/Webhook.java
+++ b/src/main/java/co/upvest/models/Webhook.java
@@ -18,6 +18,70 @@ public class Webhook implements Listable {
     private @NotNull String status;
     private @Nullable List<EventFilter> event_filters;
 
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getHMACSecretKey() {
+        return HMACSecretKey;
+    }
+
+    public void setHMACSecretKey(String HMACSecretKey) {
+        this.HMACSecretKey = HMACSecretKey;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public List<EventFilter> getEvent_filters() {
+        return event_filters;
+    }
+
+    public void setEvent_filters(List<EventFilter> event_filters) {
+        this.event_filters = event_filters;
+    }
+
     private static class EventFilter {
         private @Json(name = "event_noun") @NotNull String eventNoun;
         private @Json(name = "event_verb") @NotNull String eventVerb;

--- a/src/main/java/co/upvest/models/Webhook.java
+++ b/src/main/java/co/upvest/models/Webhook.java
@@ -1,0 +1,63 @@
+package co.upvest.models;
+
+import com.squareup.moshi.Json;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+public class Webhook implements Listable {
+    private @NotNull String id;
+    private @NotNull String url;
+    private @NotNull String name;
+    private @Json(name = "hmac_secret_key") @NotNull String HMACSecretKey;
+    private Map<String, String> headers;
+    private @NotNull String version;
+    private @NotNull String status;
+    private @Nullable List<EventFilter> event_filters;
+
+    private static class EventFilter {
+        private @Json(name = "event_noun") @NotNull String eventNoun;
+        private @Json(name = "event_verb") @NotNull String eventVerb;
+        private @Json(name = "limit_to_application") @NotNull String limitToApplication;
+        private @Json(name = "max_confirmations") @NotNull String maxConfirmations;
+        private @Json(name = "protocol_name") @NotNull String protocolName;
+        private @Json(name = "wallet_address") @NotNull String walletAddress;
+
+        public EventFilter(String eventNoun, String eventVerb, String limitToApplication, String maxConfirmations, String protocolName, String walletAddress) {
+            this.eventNoun = eventNoun;
+            this.eventVerb = eventVerb;
+            this.limitToApplication = limitToApplication;
+            this.maxConfirmations = maxConfirmations;
+            this.protocolName = protocolName;
+            this.walletAddress = walletAddress;
+        }
+
+        public String getEventNoun() {
+            return eventNoun;
+        }
+
+        public String getEventVerb() {
+            return eventVerb;
+        }
+
+        public String getLimitToApplication() {
+            return limitToApplication;
+        }
+
+        public String getMaxConfirmations() {
+            return maxConfirmations;
+        }
+
+        public String getProtocolName() {
+            return protocolName;
+        }
+
+        public String getWalletAddress() {
+            return walletAddress;
+        }
+    }
+}
+

--- a/src/main/java/co/upvest/models/WebhookParams.java
+++ b/src/main/java/co/upvest/models/WebhookParams.java
@@ -1,0 +1,60 @@
+package co.upvest.models;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class WebhookParams {
+
+    private @NotNull
+    String url;
+    private @NotNull
+    String name;
+    private @NotNull
+    String hmac_secret_key;
+    private @Nullable
+    Map<String, String> headers;
+    private @NotNull
+    String version;
+    private @NotNull
+    String status;
+    private @NotNull
+    List<String> event_filters;
+
+    public WebhookParams(String url, String name, String hmac_secret_key, Map<String, String> headers, String version, String status) {
+        this.url = url;
+        this.name = name;
+        this.hmac_secret_key = hmac_secret_key;
+        this.headers = headers;
+        this.version = version;
+        this.status = status;
+    }
+
+    public WebhookParams(String url, String name, String hmac_secret_key, Map<String, String> headers, String version, String status, List<String> event_filters) {
+        this.url = url;
+        this.name = name;
+        this.hmac_secret_key = hmac_secret_key;
+        this.headers = headers;
+        this.version = version;
+        this.status = status;
+        this.event_filters = event_filters;
+    }
+
+    public Map<String, Object> toMap() {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("url", url);
+        params.put("name", name);
+        params.put("hmac_secret_key", hmac_secret_key);
+        params.put("headers", headers);
+        params.put("version", version);
+        params.put("status", status);
+        params.put("event_filters", event_filters);
+
+        return params.entrySet().stream().filter(x -> x.getValue() != null)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+}

--- a/src/main/java/co/upvest/models/WebhookParams.java
+++ b/src/main/java/co/upvest/models/WebhookParams.java
@@ -10,20 +10,13 @@ import java.util.stream.Collectors;
 
 public class WebhookParams {
 
-    private @NotNull
-    String url;
-    private @NotNull
-    String name;
-    private @NotNull
-    String hmac_secret_key;
-    private @Nullable
-    Map<String, String> headers;
-    private @NotNull
-    String version;
-    private @NotNull
-    String status;
-    private @NotNull
-    List<String> event_filters;
+    private @NotNull String url;
+    private @NotNull String name;
+    private @NotNull String hmac_secret_key;
+    private @Nullable Map<String, String> headers;
+    private @NotNull String version;
+    private @NotNull String status;
+    private @NotNull List<String> event_filters;
 
     public WebhookParams(String url, String name, String hmac_secret_key, Map<String, String> headers, String version, String status) {
         this.url = url;
@@ -34,13 +27,63 @@ public class WebhookParams {
         this.status = status;
     }
 
-    public WebhookParams(String url, String name, String hmac_secret_key, Map<String, String> headers, String version, String status, List<String> event_filters) {
+    public WebhookParams() {
+
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
         this.url = url;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
         this.name = name;
+    }
+
+    public String getHMACSecretKey() {
+        return hmac_secret_key;
+    }
+
+    public void setHMACSecretKey(String hmac_secret_key) {
         this.hmac_secret_key = hmac_secret_key;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
         this.headers = headers;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
         this.version = version;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
         this.status = status;
+    }
+
+    public List<String> getEventFilters() {
+        return event_filters;
+    }
+
+    public void setEventFilters(List<String> event_filters) {
         this.event_filters = event_filters;
     }
 

--- a/src/test/integration/java/co/upvest/TenancyAPITest.java
+++ b/src/test/integration/java/co/upvest/TenancyAPITest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -230,6 +232,65 @@ public class TenancyAPITest {
             assertEquals("ETH and ERC20 get combined in 1 wallet.", assetIds.length - 1, user.getWalletIds().length);
             assertTrue(TestHelper.isValidRecoveryKit(user.getRecoverykit()));
 
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test public void testWebhooksVerify() {
+        TenancyAPI tenancyAPI = TestHelper.getTenancyAPI();
+        String url = TestHelper.config.getJSONObject("webhooks").getString("webhook_verification_url");
+
+        try {
+            boolean isVerified = tenancyAPI.webhooks().verify(url);
+            assertTrue(isVerified);
+
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test public void testWebhooksCreate() {
+        TenancyAPI tenancyAPI = TestHelper.getTenancyAPI();
+        WebhookParams params = TestHelper.getWebhookParams();
+
+        try {
+            Webhook webhook = tenancyAPI.webhooks().create(params);
+
+            assertEquals(params.getVersion(), webhook.getVersion());
+            assertEquals(params.getStatus(), webhook.getStatus());
+
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test public void testWebhooksListAndGet() {
+        TenancyAPI tenancyAPI = TestHelper.getTenancyAPI();
+
+        try {
+            Webhook[] webhooks = tenancyAPI.webhooks().list().toArray();
+
+            for (Webhook webhook : webhooks) {
+                Webhook otherWebhook = tenancyAPI.webhooks().get(webhook.getId());
+
+                assertEquals(webhook.getUrl(), otherWebhook.getUrl());
+            }
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+    }
+
+    @Test public void testWebhooksDelete() {
+        TenancyAPI tenancyAPI = TestHelper.getTenancyAPI();
+        WebhookParams params = TestHelper.getWebhookParams();
+
+        try {
+            Webhook webhook = tenancyAPI.webhooks().create(params);
+            // TODO: test retrieve after delete
+            boolean isDeleted = tenancyAPI.webhooks().delete(webhook.getId());
+
+            assertTrue(isDeleted);
         } catch (Exception e) {
             fail(e.getMessage());
         }

--- a/src/test/integration/java/co/upvest/TestHelper.java
+++ b/src/test/integration/java/co/upvest/TestHelper.java
@@ -8,6 +8,9 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -150,5 +153,26 @@ public class TestHelper {
 
         Wallet wallet = walletAdapter.fromJson(source);
         return wallet;
+    }
+
+    public static WebhookParams getWebhookParams() {
+        String url = TestHelper.config.getJSONObject("webhooks").getString("webhook_url");
+
+        WebhookParams params = new WebhookParams();
+        params.setUrl(url);
+        params.setName(String.format("test-webhook-%s",  TestHelper.getRandomHexString(8)));
+
+        Map<String, String> headers = new java.util.HashMap<>();
+        headers.put("X-Test", "Hello world!");
+        params.setHeaders(headers);
+
+        params.setVersion("1.2");
+        params.setStatus("ACTIVE");
+
+        List<String> event_filters = Arrays.asList(new String[] {"upvest.wallet.created", "ropsten.block.*", "upvest.echo.post"});
+        params.setEventFilters(event_filters);
+
+        params.setHMACSecretKey("abcdef");
+        return params;
     }
 }


### PR DESCRIPTION
This is not ready for merge.

The server returns inconsistent serialised response, specifically on the `event_filters` field. Given a string "upvest.wallet.created" event, the server should return an object representation of this. Instead, some of th events are serialized as objects, and others just as sent. 

Given this request data to create a new webhook

```json
{
  "id": "388d5dec-bca3-4464-be13-eccf45f1fa8d",
  "url": "https://us-central1-upvest-development.cloudfunctions.net/httpRequestToPubsubMessage/yao-webhook-test",
  "name": "test-webhook-52990d12-131e-11ea-bef8-acde48001122",
  "hmac_secret_key": "abcdef",
  "headers": {
    "X-Test": "Hello world!"
  },
  "version": "1.2",
  "status": "ACTIVE",
  "event_filters": [
    "upvest.wallet.created",
    "ropsten.block",
    "upvest.echo.post"
  ]
}
```

The server responds:

```json
{
  "id": "388d5dec-bca3-4464-be13-eccf45f1fa8d",
  "url": "https://us-central1-upvest-development.cloudfunctions.net/httpRequestToPubsubMessage/yao-webhook-test",
  "name": "test-webhook-52990d12-131e-11ea-bef8-acde48001122",
  "hmac_secret_key": "abcdef",
  "headers": {
    "X-Test": "Hello world!"
  },
  "version": "1.2",
  "status": "ACTIVE",
  "event_filters": [
    "upvest.wallet.created",
    {
      "event_noun": "block",
      "event_verb": null,
      "limit_to_application": false,
      "max_confirmations": null,
      "protocol_name": "ropsten",
      "wallet_address": null
    },
    "upvest.echo.post"
  ]
}
```
